### PR TITLE
Fix podspec and project.pbxproj for the latest Pokeregi updates

### DIFF
--- a/Pokepay.podspec
+++ b/Pokepay.podspec
@@ -11,7 +11,7 @@ iOS SDK for Pokepay written in Swift.
   s.author        = { "Eitaro Fukamachi" => "eitaro.fukamachi@pocket-change.jp" }
   s.platform      = :ios, "10.0"
   s.source        = { :git => "https://github.com/pokepay/ios-sdk.git", :tag => "#{s.version}" }
-  s.source_files  = "Sources/**/*.swift"
+  s.source_files  = "Sources/**/*.swift", "Sources/**/*.h"
   s.swift_version = "5.0"
   s.dependency "APIKit", "~> 4.0.0"
   s.dependency "Result", "~> 4.0.0"

--- a/Pokepay.podspec
+++ b/Pokepay.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "Pokepay"
-  s.version      = "1.2.1"
+  s.version      = "1.3.0"
   s.summary      = "Pokepay iOS SDK."
   s.description  = <<-DESC
 iOS SDK for Pokepay written in Swift.

--- a/Pokepay.xcodeproj/project.pbxproj
+++ b/Pokepay.xcodeproj/project.pbxproj
@@ -191,6 +191,7 @@
 		DFA1232D21911C3F007C2750 /* MessagingAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = DFA122E321911C3F007C2750 /* MessagingAPI.swift */; };
 		DFA1232E21911C3F007C2750 /* RequestProxy.swift in Sources */ = {isa = PBXBuildFile; fileRef = DFA122E421911C3F007C2750 /* RequestProxy.swift */; };
 		DFA123302191212D007C2750 /* MessageUnreadCount.swift in Sources */ = {isa = PBXBuildFile; fileRef = DFA1232F2191212D007C2750 /* MessageUnreadCount.swift */; };
+		DFB910EB230CF47B0065FE07 /* Security.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DFB910EA230CF47B0065FE07 /* Security.framework */; };
 		DFD201FA21B534F300A1D59B /* JwtResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = DFD201F921B534F300A1D59B /* JwtResult.swift */; };
 /* End PBXBuildFile section */
 
@@ -300,6 +301,7 @@
 		DFA122E321911C3F007C2750 /* MessagingAPI.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MessagingAPI.swift; sourceTree = "<group>"; };
 		DFA122E421911C3F007C2750 /* RequestProxy.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RequestProxy.swift; sourceTree = "<group>"; };
 		DFA1232F2191212D007C2750 /* MessageUnreadCount.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageUnreadCount.swift; sourceTree = "<group>"; };
+		DFB910EA230CF47B0065FE07 /* Security.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Security.framework; path = System/Library/Frameworks/Security.framework; sourceTree = SDKROOT; };
 		DFD201F921B534F300A1D59B /* JwtResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JwtResult.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -318,6 +320,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 0;
 			files = (
+				DFB910EB230CF47B0065FE07 /* Security.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -356,6 +359,7 @@
 		B4AF946421CB76030049B71C /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				DFB910EA230CF47B0065FE07 /* Security.framework */,
 				B4AF946621CB76030049B71C /* APIKit.framework */,
 				B4AF946521CB76030049B71C /* Result.framework */,
 			);


### PR DESCRIPTION
Fix Pokepay.podspec and pbxproj to build properly with CocoaPods and Carthage.

* Add *.h files to podspec
* Add Security.framework to project.pbxproj
* Update the version of podspec to 1.3.0.