### PR TITLE
fix query encoding

### DIFF
--- a/Pokepay.podspec
+++ b/Pokepay.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "Pokepay"
-  s.version      = "1.4.4"
+  s.version      = "1.4.5"
   s.summary      = "Pokepay iOS SDK."
   s.description  = <<-DESC
 iOS SDK for Pokepay written in Swift.

--- a/Pokepay.xcodeproj/Pokepay_Info.plist
+++ b/Pokepay.xcodeproj/Pokepay_Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.4.4</string>
+	<string>1.4.5</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/Sources/Pokepay/Pokepay.swift
+++ b/Sources/Pokepay/Pokepay.swift
@@ -333,7 +333,7 @@ public struct Pokepay {
             guard let contact = contact else {
                 return url
             }
-            let encodedContact = contact.addingPercentEncoding(withAllowedCharacters: NSCharacterSet.urlQueryAllowed.subtracting(CharacterSet(charactersIn: "+")))
+            let encodedContact = contact.addingPercentEncoding(withAllowedCharacters: NSCharacterSet.alphanumerics)
             precondition(encodedContact != nil)
             return "\(url)&contact=\(encodedContact!)"
         }

--- a/Sources/Pokepay/Pokepay.swift
+++ b/Sources/Pokepay/Pokepay.swift
@@ -333,7 +333,7 @@ public struct Pokepay {
             guard let contact = contact else {
                 return url
             }
-            let encodedContact = contact.addingPercentEncoding(withAllowedCharacters: NSCharacterSet.urlQueryAllowed)
+            let encodedContact = contact.addingPercentEncoding(withAllowedCharacters: NSCharacterSet.urlQueryAllowed.subtracting(CharacterSet(charactersIn: "+")))
             precondition(encodedContact != nil)
             return "\(url)&contact=\(encodedContact!)"
         }


### PR DESCRIPTION
URL内のemailが正しくエンコードされていなかったので修正（emailでは＋を半角スペースではなくプラスとして使いたい）