### PR TITLE
Pokepay client with custom domain

### DIFF
--- a/Sources/Pokepay/BankAPI/PrivateMoney/GetPrivateMoney.swift
+++ b/Sources/Pokepay/BankAPI/PrivateMoney/GetPrivateMoney.swift
@@ -1,0 +1,28 @@
+import APIKit
+
+public extension BankAPI.PrivateMoney {
+
+    struct GetPrivateMoney: BankRequest {
+        public let privateMoneyId:String
+
+        public typealias Response = PrivateMoney
+
+        public init(privateMoneyId: String) {
+            self.privateMoneyId = privateMoneyId
+        }
+
+        public var method: HTTPMethod {
+            return .get
+        }
+
+        public var path: String {
+            return "/private-moneys/\(privateMoneyId)"
+        }
+
+        public var parameters: Any? {
+            return [:]
+        }
+
+    }
+
+}

--- a/Sources/Pokepay/Pokepay.swift
+++ b/Sources/Pokepay/Pokepay.swift
@@ -64,6 +64,12 @@ public struct Pokepay {
             self.customDomain = customDomain
         }
         
+        /**
+         Create a client object with custom domain.
+         
+         - warning
+         It is encouraged to get the client once and use it throughout the application since this method needs to call api endpoint to get a custom domain.
+        */
         public static func withCustomDomain(accessToken: String, isMerchant: Bool = false, env: Env = .development, challange: String, handler: @escaping (Result<Client, PokepayError>) -> Void = { _ in }) {
             let client = Client(accessToken: accessToken, isMerchant: true, env: env)
             client.send(BankAPI.PrivateMoney.GetPrivateMoney(privateMoneyId: challange)) { result in

--- a/Sources/Pokepay/Responses/PrivateMoney.swift
+++ b/Sources/Pokepay/Responses/PrivateMoney.swift
@@ -19,6 +19,7 @@ public struct PrivateMoney: Codable {
     public let paymentActUrl: String?
     public let commercialActUrl: String?
     public let canUseCreditCard: Bool?
+    public let customDomainName: String?
 
     private enum CodingKeys: String, CodingKey {
         case id
@@ -39,5 +40,6 @@ public struct PrivateMoney: Codable {
         case paymentActUrl = "payment_act_url"
         case commercialActUrl = "commercial_act_url"
         case canUseCreditCard = "can_use_credit_card"
+        case customDomainName = "custom_domain_name"
     }
 }


### PR DESCRIPTION
For [this custom domain issue](https://github.com/pokepay/pokepay-server/issues/2936)

How to get client with custom domain

```swift
Pokepay.Client.withCustomDomain(accessToken: "ZhwMsfoAyWZMGrCAKrrofmwYHV82GkUcf3kYSZYYf1oDKVvFAPIKuefyQoc1KDVr",
                                isMerchant: true,
                                env: .production,
                                challange: "private-money-id") { result in
            switch result {
            case .success(let client):
                print(client.wwwBaseURL)
                // use client as before
            case .failure(let error):
                print(error)
            }
        }
```

This drawback of implementing this way is the user need to use a callback since this is an async function.

Another way we can implement this is by saving private_money_id and calling the API every time we want to use it. But the drawback is multiple API calls are need for get bill/check/cashtray etc.

**Please give me instructions on how to run unit tests for this project.** I've tried running tests for hours but couldn't figure out how to run them.