### PR TITLE
Date parsing error with 12 hours format (Bugfix)

### DIFF
--- a/Pokepay.podspec
+++ b/Pokepay.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "Pokepay"
-  s.version      = "1.8.1"
+  s.version      = "1.8.2"
   s.summary      = "Pokepay iOS SDK."
   s.description  = <<-DESC
 iOS SDK for Pokepay written in Swift.

--- a/Pokepay.xcodeproj/Pokepay_Info.plist
+++ b/Pokepay.xcodeproj/Pokepay_Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.8.1</string>
+	<string>1.8.2</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/Sources/Pokepay/BankAPI/BankAPIJSONDecoder.swift
+++ b/Sources/Pokepay/BankAPI/BankAPIJSONDecoder.swift
@@ -6,6 +6,7 @@ public let dateFormatter = DateFormatter()
         super.init()
         dateFormatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSSSSS'Z'"
         dateFormatter.timeZone = TimeZone(secondsFromGMT: 0)
+        dateFormatter.locale = Locale(identifier: "en_US_POSIX")
         dateDecodingStrategy = .formatted(dateFormatter)
     }
 }


### PR DESCRIPTION
## Problem
The SDK is producing an error when the date and time format of the device is set to 12-hour clock.

## Fix
The formatter's locale is set to a fixed locale instead of using the device locale.