### PR TITLE
OAuth User Setting URL

### DIFF
--- a/Pokepay.podspec
+++ b/Pokepay.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "Pokepay"
-  s.version      = "1.8.3"
+  s.version      = "1.8.4"
   s.summary      = "Pokepay iOS SDK."
   s.description  = <<-DESC
 iOS SDK for Pokepay written in Swift.

--- a/Pokepay.xcodeproj/Pokepay_Info.plist
+++ b/Pokepay.xcodeproj/Pokepay_Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.8.3</string>
+	<string>1.8.4</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/Sources/Pokepay/BankAPI/User/GetUserSettingUrl.swift
+++ b/Sources/Pokepay/BankAPI/User/GetUserSettingUrl.swift
@@ -1,0 +1,22 @@
+
+import APIKit
+
+public extension BankAPI.User {
+    struct GetUserSettingUrl: BankRequest {
+        public let accessCode: String
+
+        public typealias Response = UserSettingUrl
+
+        public init(accessCode: String) {
+            self.accessCode = accessCode
+        }
+
+        public var method: HTTPMethod {
+            return .post
+        }
+
+        public var path: String {
+            return "/oauth/full-access"
+        }
+    }
+}

--- a/Sources/Pokepay/Pokepay.swift
+++ b/Sources/Pokepay/Pokepay.swift
@@ -308,6 +308,10 @@ public struct Pokepay {
                 }
             }
         }
+        
+        public func getUserSettingUrl(handler: @escaping (Result<UserSettingUrl, PokepayError>) -> Void = { _ in }) {
+            send(BankAPI.User.GetUserSettingUrl(accessCode: accessToken), handler: handler)
+        }
     }
     public struct OAuthClient {
         let clientId: String
@@ -322,7 +326,7 @@ public struct Pokepay {
                 return URL(string: "https://www-\(env.rawValue).pokepay.jp")!
             }
         }
-
+        
         public init(clientId: String, clientSecret: String, env: Env = .development) {
             self.clientId = clientId
             self.clientSecret = clientSecret

--- a/Sources/Pokepay/Responses/UserSettingUrl.swift
+++ b/Sources/Pokepay/Responses/UserSettingUrl.swift
@@ -1,0 +1,6 @@
+import Foundation
+
+public struct UserSettingUrl: Codable {
+    public let url: String
+}
+


### PR DESCRIPTION
### Related Issue
[#3078](https://github.com/pokepay/pokepay-server/issues/3078)

#### Implementation
Added GetUserSettingUrl 

#### QA Method
```swift
let client = Pokepay.Client(accessToken: "8DZN-jCfqOTwKALYjWa2lYj7we8GYGTGi2UzT4cVERISl6qBIuNurDk4TMdqIUEU",
                            isMerchant: true,
                            env: .development)

client.getUserSettingUrl() { result in
    switch result {
    case .success(let url):
        print(url)
    case .failure(let error):
        print(error)
    }
}
```