### PR TITLE
Top up method settings for Private Money

### DIFF
--- a/Pokepay.xcodeproj/project.pbxproj
+++ b/Pokepay.xcodeproj/project.pbxproj
@@ -41,6 +41,8 @@
 		444D2FAE2F8393A0006EF6BE /* JihanpiTransaction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 444D2FAB2F8393A0006EF6BE /* JihanpiTransaction.swift */; };
 		444D2FAF2F8393A0006EF6BE /* JihanpiVendingMachine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 444D2FAC2F8393A0006EF6BE /* JihanpiVendingMachine.swift */; };
 		444D2FB02F8393A0006EF6BE /* JihanpiTransaction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 444D2FAB2F8393A0006EF6BE /* JihanpiTransaction.swift */; };
+		445A62682FDA86E5006F55B2 /* TopupMethod.swift in Sources */ = {isa = PBXBuildFile; fileRef = 445A62672FDA86E5006F55B2 /* TopupMethod.swift */; };
+		445A62692FDA86E5006F55B2 /* TopupMethod.swift in Sources */ = {isa = PBXBuildFile; fileRef = 445A62672FDA86E5006F55B2 /* TopupMethod.swift */; };
 		4A6A88612EA21AAE0055A132 /* GetPrivateMoneyCoupons.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A6A87E12EA21AAE0055A132 /* GetPrivateMoneyCoupons.swift */; };
 		4A6A88622EA21AAE0055A132 /* PrivateMoney.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A6A88432EA21AAE0055A132 /* PrivateMoney.swift */; };
 		4A6A88632EA21AAE0055A132 /* BankAPIRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A6A88072EA21AAE0055A132 /* BankAPIRequest.swift */; };
@@ -365,6 +367,7 @@
 		444D2FA32F839380006EF6BE /* GetJihanpiTransactionByRequestId.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetJihanpiTransactionByRequestId.swift; sourceTree = "<group>"; };
 		444D2FAB2F8393A0006EF6BE /* JihanpiTransaction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JihanpiTransaction.swift; sourceTree = "<group>"; };
 		444D2FAC2F8393A0006EF6BE /* JihanpiVendingMachine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JihanpiVendingMachine.swift; sourceTree = "<group>"; };
+		445A62672FDA86E5006F55B2 /* TopupMethod.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopupMethod.swift; sourceTree = "<group>"; };
 		4A6A87B92EA21AAE0055A132 /* CreateAccount.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateAccount.swift; sourceTree = "<group>"; };
 		4A6A87BA2EA21AAE0055A132 /* CreateAccountCpmToken.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateAccountCpmToken.swift; sourceTree = "<group>"; };
 		4A6A87BB2EA21AAE0055A132 /* CreateAccountSevenElevenAtmSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateAccountSevenElevenAtmSession.swift; sourceTree = "<group>"; };
@@ -794,6 +797,7 @@
 		4A6A884F2EA21AAE0055A132 /* Responses */ = {
 			isa = PBXGroup;
 			children = (
+				445A62672FDA86E5006F55B2 /* TopupMethod.swift */,
 				4443E79E2FB1C0E5003A4EB9 /* ExchangedToken.swift */,
 				440E00C72F99C55600751068 /* CvsAuthorization.swift */,
 				440E00C82F99C55600751068 /* PaginatedCvsAuthorizations.swift */,
@@ -1184,6 +1188,7 @@
 				4A6A893C2EA21AAE0055A132 /* GetBankPay.swift in Sources */,
 				4A6A893D2EA21AAE0055A132 /* User.swift in Sources */,
 				4A6A893E2EA21AAE0055A132 /* AccessToken.swift in Sources */,
+				445A62692FDA86E5006F55B2 /* TopupMethod.swift in Sources */,
 				4A6A893F2EA21AAE0055A132 /* CardsTopUp.swift in Sources */,
 				4A6A89402EA21AAE0055A132 /* CancelTransaction.swift in Sources */,
 				4A6A89412EA21AAE0055A132 /* DeleteCheck.swift in Sources */,
@@ -1316,6 +1321,7 @@
 				4A6A88852EA21AAE0055A132 /* BankAPI.swift in Sources */,
 				4A6A88862EA21AAE0055A132 /* VeritransAPI.swift in Sources */,
 				4A6A88872EA21AAE0055A132 /* Terminal.swift in Sources */,
+				445A62682FDA86E5006F55B2 /* TopupMethod.swift in Sources */,
 				4A6A88882EA21AAE0055A132 /* AccountCpmToken.swift in Sources */,
 				4A6A88892EA21AAE0055A132 /* CreateCashtray.swift in Sources */,
 				4A6A888A2EA21AAE0055A132 /* UpdateCheck.swift in Sources */,

--- a/Sources/Pokepay/Responses/PrivateMoney.swift
+++ b/Sources/Pokepay/Responses/PrivateMoney.swift
@@ -23,10 +23,6 @@ public struct PrivateMoney: Codable {
     public let customDomainName: String?
     public let topupMethods: [TopupMethod]?
 
-    public var creditCardTopupMethod: TopupMethod? {
-        return topupMethods?.first { method in method.isCreditCard }
-    }
-
     private enum CodingKeys: String, CodingKey {
         case id
         case name

--- a/Sources/Pokepay/Responses/PrivateMoney.swift
+++ b/Sources/Pokepay/Responses/PrivateMoney.swift
@@ -21,6 +21,11 @@ public struct PrivateMoney: Codable {
     public let canUseCreditCard: Bool?
     public let canUseC2CTransfer: Bool
     public let customDomainName: String?
+    public let topupMethods: [TopupMethod]?
+
+    public var creditCardTopupMethod: TopupMethod? {
+        return topupMethods?.first { method in method.isCreditCard }
+    }
 
     private enum CodingKeys: String, CodingKey {
         case id
@@ -43,5 +48,6 @@ public struct PrivateMoney: Codable {
         case canUseCreditCard = "can_use_credit_card"
         case canUseC2CTransfer = "can_use_c2c_transfer"
         case customDomainName = "custom_domain_name"
+        case topupMethods = "topup_methods"
     }
 }

--- a/Sources/Pokepay/Responses/TopupMethod.swift
+++ b/Sources/Pokepay/Responses/TopupMethod.swift
@@ -1,0 +1,14 @@
+import Foundation
+
+public struct TopupMethod: Codable {
+    public static let typeCreditCard = "credit-card"
+
+    public let type: String
+    public let name: String
+    public let amounts: [Double]?
+    public let range: [Double]?
+
+    public var isCreditCard: Bool {
+        return type == TopupMethod.typeCreditCard
+    }
+}

--- a/Sources/Pokepay/Responses/TopupMethod.swift
+++ b/Sources/Pokepay/Responses/TopupMethod.swift
@@ -1,14 +1,9 @@
 import Foundation
 
 public struct TopupMethod: Codable {
-    public static let typeCreditCard = "credit-card"
-
+    // "type" can be "credit-card", "sevenbank-atm", "paytree-bank", or "cvs"
     public let type: String
     public let name: String
     public let amounts: [Double]?
     public let range: [Double]?
-
-    public var isCreditCard: Bool {
-        return type == TopupMethod.typeCreditCard
-    }
 }


### PR DESCRIPTION
This pull request introduces support for handling multiple top-up methods in the `PrivateMoney` model, including the addition of a new `TopupMethod` struct. The changes allow for more flexible and detailed representation of available top-up options, such as credit card and others, and provide convenient access to credit card top-up information.

**Enhancements to top-up methods support:**

* Added a new `TopupMethod` struct in `TopupMethod.swift` to represent different top-up methods, including properties for type, name, available amounts, and range, as well as a computed property to identify credit card methods.
* Updated the `PrivateMoney` struct in `PrivateMoney.swift` to include a `topupMethods` property (an array of `TopupMethod`) and a computed property `creditCardTopupMethod` to easily access the credit card top-up method if available.
* Modified the `CodingKeys` in `PrivateMoney` to support decoding the new `topup_methods` field from JSON.