### PR TITLE
Regenerate ios-sdk with pokepay-sdk-generator#71 (amount: Int → Double)

### DIFF
--- a/Sources/Pokepay/BankAPI/Transaction/CreateBillTransaction.swift
+++ b/Sources/Pokepay/BankAPI/Transaction/CreateBillTransaction.swift
@@ -6,13 +6,13 @@ public extension BankAPI.Transaction {
         public let requestId: String
         public let billId: String
         public let accountId: String?
-        public let amount: Int?
+        public let amount: Double?
         public let couponId: String?
         public let strategy: String?
 
         public typealias Response = UserTransactionWithFallback
 
-        public init(requestId: String, billId: String, accountId: String? = nil, amount: Int? = nil, couponId: String? = nil, strategy: String? = nil) {
+        public init(requestId: String, billId: String, accountId: String? = nil, amount: Double? = nil, couponId: String? = nil, strategy: String? = nil) {
             self.requestId = requestId
             self.billId = billId
             self.accountId = accountId

--- a/Sources/Pokepay/BankAPI/Transaction/CreateCpmTransaction.swift
+++ b/Sources/Pokepay/BankAPI/Transaction/CreateCpmTransaction.swift
@@ -6,13 +6,13 @@ public extension BankAPI.Transaction {
         public let requestId: String
         public let cpmToken: String
         public let accountId: String?
-        public let amount: Int
+        public let amount: Double
         public let products: [Product]?
         public let topupQuotaId: Int?
 
         public typealias Response = UserTransactionWithFallback
 
-        public init(requestId: String, cpmToken: String, accountId: String? = nil, amount: Int, products: [Product]? = nil, topupQuotaId: Int? = nil) {
+        public init(requestId: String, cpmToken: String, accountId: String? = nil, amount: Double, products: [Product]? = nil, topupQuotaId: Int? = nil) {
             self.requestId = requestId
             self.cpmToken = cpmToken
             self.accountId = accountId

--- a/Sources/Pokepay/Responses/AccountTopupStats.swift
+++ b/Sources/Pokepay/Responses/AccountTopupStats.swift
@@ -2,9 +2,9 @@
 import Foundation
 
 public struct AccountTopupStats: Codable {
-    public let currentAmount: Int
-    public let limitAmount: Int
-    public let remainingAmount: Int
+    public let currentAmount: Double
+    public let limitAmount: Double
+    public let remainingAmount: Double
     public let startedAt: String?
 
     private enum CodingKeys: String, CodingKey {

--- a/Sources/Pokepay/Responses/UserTransactionWithFallback.swift
+++ b/Sources/Pokepay/Responses/UserTransactionWithFallback.swift
@@ -4,12 +4,12 @@ import Foundation
 public struct UserTransactionWithFallback: Codable {
     public let id: String
     public let user: User
-    public let balance: Int
-    public let amount: Int
-    public let moneyAmount: Int
-    public let pointAmount: Int
-    public let rawPointAmount: Int?
-    public let campaignPointAmount: Int?
+    public let balance: Double
+    public let amount: Double
+    public let moneyAmount: Double
+    public let pointAmount: Double
+    public let rawPointAmount: Double?
+    public let campaignPointAmount: Double?
     public let account: Account
     public let description: String
     public let doneAt: String

--- a/Sources/Pokepay/Responses/UserTransactionWithTransfers.swift
+++ b/Sources/Pokepay/Responses/UserTransactionWithTransfers.swift
@@ -4,12 +4,12 @@ import Foundation
 public struct UserTransactionWithTransfers: Codable {
     public let id: String
     public let user: User
-    public let balance: Int
-    public let amount: Int
-    public let moneyAmount: Int
-    public let pointAmount: Int
-    public let rawPointAmount: Int?
-    public let campaignPointAmount: Int?
+    public let balance: Double
+    public let amount: Double
+    public let moneyAmount: Double
+    public let pointAmount: Double
+    public let rawPointAmount: Double?
+    public let campaignPointAmount: Double?
     public let account: Account
     public let description: String
     public let doneAt: String

--- a/Sources/Pokepay/Responses/UserTransferWithoutAccount.swift
+++ b/Sources/Pokepay/Responses/UserTransferWithoutAccount.swift
@@ -3,9 +3,9 @@ import Foundation
 
 public struct UserTransferWithoutAccount: Codable {
     public let id: String
-    public let amount: Int
-    public let moneyAmount: Int
-    public let pointAmount: Int
+    public let amount: Double
+    public let moneyAmount: Double
+    public let pointAmount: Double
     public let description: String
     public let doneAt: String
     public let type: String


### PR DESCRIPTION
## Summary

pokepay-server の `docs/api/bank.yaml` から再生成。生成器側の型変換バグ修正 (pokepay/pokepay-sdk-generator#71) を取り込む。

OpenAPI の `type: number` (`format: decimal`) が Swift の `Int` にマップされていた。Swift 生成を追加した当初 (pokepay-sdk-generator 60a0918) からの誤りで、リグレッションではない。

- 小数を含む金額でレスポンスのデコードが `JSONDecoder` の `typeMismatch` になっていた
- flutter-sdk の `ios/Classes/AutogenMethodHandlers.swift` は `args["amount"] as? Double` を `BankAPI.Transaction.CreateBillTransaction(amount:)` に渡しており、型が合っていなかった。本 PR で解消する

android-sdk (`Double`)、flutter-sdk の Dart (`double`) はいずれも浮動小数にマップしており、ios-sdk だけが例外だった。本 SDK の手書きレスポンス型 (`Account.balance`, `Check.amount`, `Cashtray.amount`, `Bill.amount`, `Transfer.amount` 等) が一貫して `Double` を使っているのとも食い違っていた。

## ⚠️ 破壊的変更

以下 6 ファイル 20 フィールドの型が `Int` → `Double` に変わる。**利用アプリのソース互換性が壊れる**ため、リリース時のバージョン付けに注意。

| ファイル | フィールド |
|---|---|
| `BankAPI/Transaction/CreateBillTransaction.swift` | `amount` |
| `BankAPI/Transaction/CreateCpmTransaction.swift` | `amount` |
| `Responses/UserTransactionWithFallback.swift` | `balance` `amount` `moneyAmount` `pointAmount` `rawPointAmount` `campaignPointAmount` |
| `Responses/UserTransactionWithTransfers.swift` | 同上 6 件 |
| `Responses/UserTransferWithoutAccount.swift` | `amount` `moneyAmount` `pointAmount` |
| `Responses/AccountTopupStats.swift` | `currentAmount` `limitAmount` `remainingAmount` |

`type: integer` の `AccountTopupQuota.amount` / `CvsAuthorization.amount` は `Int` のまま。変更後のフィールドは android-sdk の `Double` フィールドと一致する。

## Test plan

- [x] 生成前後で `// DO NOT EDIT` を含む `.swift` は 50 件のまま。削除対象と生成対象の集合が完全一致し、消失・新規追加ともゼロ
- [x] 手書きファイル (`BankAPI/Bill/`, `Cashtray/`, `Check/`, `CpmToken/`, `PrivateMoney/`, `Terminal/`, `User/` 等) は未変更。`BankAPI.swift` の namespace 14 件も変化なし
- [x] 変更された 6 型のフィールドを読む手書きコードが本リポジトリに存在しないことを確認 (`typealias Response` での参照のみ)。`PokepayTests` / `Tests` もこれらの型を参照していない
- [x] 生成器側で 26 リクエスト / 23 レスポンスのシグネチャを android-sdk と機械照合し一致を確認。flutter-sdk の Swift ネイティブリンク 25 メソッドの引数ラベル・順序・キャスト型とも一致
- [x] Xcode / CI でのビルド確認 — 生成環境に Swift ツールチェーンが無いため未実施

## 関連

- pokepay/pokepay-sdk-generator#71 (生成器側の修正)
- pokepay/android-sdk — 同じ生成器で再生成しても差分ゼロ (今回の修正のもう一方が、既存の手動パッチを生成器が再現するようになったもの)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
